### PR TITLE
Update ci to run on master

### DIFF
--- a/.github/workflows/ci-python.yaml
+++ b/.github/workflows/ci-python.yaml
@@ -1,7 +1,12 @@
 name: ci-python
 
 on:
+  push:
+    branches:
+      - "master"
   pull_request:
+    branches:
+      - "master"
     paths:
       - 'huak-py/**'
       - '.github/workflows/ci-python.yaml'

--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -1,7 +1,12 @@
 name: ci-rust
 
 on:
+  push:
+    branches:
+      - "master"
   pull_request:
+    branches:
+      - "master"  
     paths:
       - 'src/**'
       - 'Cargo.toml'


### PR DESCRIPTION
## Problem

Right now this is less important. As the project grows it won't be enough to ci-gate a branch in a PR. It will become possible for a PR to pass tests without passing them post-merge. If components change but a conflict doesn't occur then it's possible the change isn't tested against a recent enough hash of the project.

## Solution

At least catch this in the future by running the tests again on master. It's less resource efficient, so I may revert/close this until it's needed.