### PR TITLE
Refactor huak::pyproject and pyproject stdin

### DIFF
--- a/src/bin/huak/commands/init.rs
+++ b/src/bin/huak/commands/init.rs
@@ -8,7 +8,7 @@ use super::utils::subcommand;
 use clap::Command;
 use huak::{
     errors::{CliError, CliResult},
-    pyproject::toml::{Huak, Toml},
+    pyproject::toml::Toml,
 };
 
 pub fn arg() -> Command<'static> {
@@ -46,16 +46,18 @@ pub fn run() -> CliResult {
         ));
     }
 
-    let mut huak_table = Huak::new();
-    huak_table.set_name(name.unwrap().to_string());
-    huak_table.set_version(create_version()?);
-    huak_table.set_description(create_description()?);
-    huak_table.set_authors(create_authors()?);
-    huak_table.set_dependencies(create_dependencies("main")?);
-    huak_table.set_dev_dependencies(create_dependencies("dev")?);
-
     let mut toml = Toml::new();
-    toml.set_huak(huak_table);
+
+    toml.tool.huak.set_name(name.unwrap().to_string());
+    toml.tool.huak.set_version(create_version()?);
+    toml.tool.huak.set_description(create_description()?);
+    toml.tool.huak.set_authors(create_authors()?);
+    toml.tool
+        .huak
+        .set_dependencies(create_dependencies("main")?);
+    toml.tool
+        .huak
+        .set_dev_dependencies(create_dependencies("dev")?);
 
     let string = match toml.to_string() {
         Ok(s) => s,

--- a/src/bin/huak/commands/remove.rs
+++ b/src/bin/huak/commands/remove.rs
@@ -53,8 +53,7 @@ pub fn run(args: &ArgMatches) -> CliResult {
         }
     };
 
-    toml.remove_dependency(dependency, "dev");
-    toml.remove_dependency(dependency, "main");
+    toml.tool.huak.remove_dependency(dependency);
 
     // Attempt to prepare the serialization of pyproject.toml constructed.
     let string = match toml.to_string() {

--- a/src/bin/huak/commands/version.rs
+++ b/src/bin/huak/commands/version.rs
@@ -28,11 +28,7 @@ pub fn run() -> CliResult {
         }
     };
 
-    println!(
-        "{}-{}",
-        toml.tool().huak().name(),
-        toml.tool().huak().version()
-    );
+    println!("{}-{}", toml.tool.huak.name(), toml.tool.huak.version());
 
     Ok(())
 }

--- a/src/bin/huak/pyproject/toml.rs
+++ b/src/bin/huak/pyproject/toml.rs
@@ -1,6 +1,6 @@
 use huak::{
     errors::CliError,
-    pyproject::toml::{Huak, Toml},
+    pyproject::{toml::Toml, tools::huak::Huak},
     Dependency,
 };
 use std::io::{self, Write};
@@ -8,13 +8,13 @@ use std::io::{self, Write};
 /// Create a pyproject.toml from scratch in a directory `path`.
 #[allow(dead_code)]
 pub fn create() -> Result<Toml, CliError> {
+    // Update tool with huak table defined using stdin.
     let mut toml = Toml::new();
-    toml.set_huak(create_huak()?);
+    toml.tool.set_huak(create_huak()?);
 
     Ok(toml)
 }
 
-#[allow(dead_code)]
 /// Create huak table for toml.
 fn create_huak() -> Result<Huak, CliError> {
     let mut huak_table = Huak::new();

--- a/src/huak/pyproject/mod.rs
+++ b/src/huak/pyproject/mod.rs
@@ -1,2 +1,3 @@
 pub mod build_system;
 pub mod toml;
+pub mod tools;

--- a/src/huak/pyproject/toml.rs
+++ b/src/huak/pyproject/toml.rs
@@ -1,15 +1,11 @@
+use super::{build_system::BuildSystem, tools::Tool};
 use serde_derive::{Deserialize, Serialize};
-use toml::{value::Map, Value};
-
-use crate::Dependency;
-
-use super::build_system::BuildSystem;
 
 #[derive(Serialize, Deserialize, Default)]
 pub struct Toml {
-    tool: Tool,
+    pub tool: Tool,
     #[serde(rename = "build-system")]
-    build_system: BuildSystem,
+    pub build_system: BuildSystem,
 }
 
 impl Toml {
@@ -25,138 +21,12 @@ impl Toml {
         &self.tool
     }
 
-    pub fn remove_dependency(&mut self, name: &str, kind: &str) {
-        match kind {
-            "dev" => self.tool.huak.remove_dev_dependency(name),
-            _ => self.tool.huak.remove_dependency(name),
-        };
-    }
-
-    pub fn set_huak(&mut self, huak: Huak) {
-        self.tool.huak = huak
+    pub fn set_tool(&mut self, tool: Tool) {
+        self.tool = tool;
     }
 
     pub fn to_string(&self) -> Result<String, toml::ser::Error> {
         toml::to_string(&self)
-    }
-}
-
-#[derive(Serialize, Deserialize, Default)]
-pub struct Tool {
-    huak: Huak,
-}
-
-impl Tool {
-    pub fn new() -> Tool {
-        Tool::default()
-    }
-
-    pub fn huak(&self) -> &Huak {
-        &self.huak
-    }
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct Huak {
-    name: String,
-    version: String,
-    description: String,
-    authors: Vec<String>,
-    dependencies: Map<String, Value>,
-    #[serde(rename = "dev-dependencies")]
-    dev_dependencies: Map<String, Value>,
-}
-
-impl Default for Huak {
-    fn default() -> Huak {
-        Huak {
-            name: "".to_string(),
-            version: "0.0.1".to_string(),
-            description: "".to_string(),
-            authors: vec![],
-            dependencies: Map::new(),
-            dev_dependencies: Map::new(),
-        }
-    }
-}
-
-impl Huak {
-    pub fn new() -> Huak {
-        Huak::default()
-    }
-
-    pub fn name(&self) -> &String {
-        &self.name
-    }
-
-    pub fn set_name(&mut self, name: String) {
-        self.name = name
-    }
-
-    pub fn version(&self) -> &String {
-        &self.version
-    }
-
-    pub fn set_version(&mut self, version: String) {
-        self.version = version
-    }
-
-    pub fn description(&self) -> &String {
-        &self.description
-    }
-
-    pub fn set_description(&mut self, description: String) {
-        self.description = description
-    }
-
-    pub fn authors(&self) -> &Vec<String> {
-        &self.authors
-    }
-
-    pub fn set_authors(&mut self, authors: Vec<String>) {
-        self.authors = authors;
-    }
-
-    pub fn add_author(&mut self, author: String) {
-        self.authors.push(author);
-    }
-
-    pub fn dependencies(&self) -> &Map<String, Value> {
-        &self.dependencies
-    }
-
-    pub fn add_dependency(&mut self, dependency: Dependency) {
-        self.dependencies
-            .insert(dependency.name, Value::String(dependency.version));
-    }
-
-    pub fn set_dependencies(&mut self, dependencies: Vec<Dependency>) {
-        for dependency in dependencies {
-            self.add_dependency(dependency);
-        }
-    }
-
-    pub fn remove_dependency(&mut self, name: &str) {
-        self.dependencies.remove(name);
-    }
-
-    pub fn dev_dependencies(&self) -> &Map<String, Value> {
-        &self.dev_dependencies
-    }
-
-    pub fn add_dev_dependency(&mut self, dependency: Dependency) {
-        self.dev_dependencies
-            .insert(dependency.name, Value::String(dependency.version));
-    }
-
-    pub fn set_dev_dependencies(&mut self, dependencies: Vec<Dependency>) {
-        for dependency in dependencies {
-            self.add_dev_dependency(dependency);
-        }
-    }
-
-    pub fn remove_dev_dependency(&mut self, name: &str) {
-        self.dev_dependencies.remove(name);
     }
 }
 
@@ -203,6 +73,6 @@ build-backend = "huak.core.build.api"
 "#;
         let toml = Toml::from(string).unwrap();
 
-        assert_eq!(toml.tool().huak().name, "Test");
+        assert_eq!(toml.tool.huak.name(), "Test");
     }
 }

--- a/src/huak/pyproject/tools/huak.rs
+++ b/src/huak/pyproject/tools/huak.rs
@@ -1,0 +1,114 @@
+use serde_derive::{Deserialize, Serialize};
+use toml::{value::Map, Value};
+
+use crate::Dependency;
+
+#[derive(Serialize, Deserialize)]
+pub struct Huak {
+    name: String,
+    version: String,
+    description: String,
+    authors: Vec<String>,
+    dependencies: Map<String, Value>,
+    #[serde(rename = "dev-dependencies")]
+    dev_dependencies: Map<String, Value>,
+}
+
+impl Default for Huak {
+    fn default() -> Huak {
+        Huak {
+            name: "".to_string(),
+            version: "0.0.1".to_string(),
+            description: "".to_string(),
+            authors: vec![],
+            dependencies: Map::new(),
+            dev_dependencies: Map::new(),
+        }
+    }
+}
+
+impl Huak {
+    pub fn new() -> Huak {
+        Huak::default()
+    }
+
+    pub fn name(&self) -> &String {
+        &self.name
+    }
+
+    pub fn set_name(&mut self, name: String) {
+        self.name = name
+    }
+
+    pub fn version(&self) -> &String {
+        &self.version
+    }
+
+    pub fn set_version(&mut self, version: String) {
+        self.version = version
+    }
+
+    pub fn description(&self) -> &String {
+        &self.description
+    }
+
+    pub fn set_description(&mut self, description: String) {
+        self.description = description
+    }
+
+    pub fn authors(&self) -> &Vec<String> {
+        &self.authors
+    }
+
+    pub fn set_authors(&mut self, authors: Vec<String>) {
+        self.authors = authors;
+    }
+
+    pub fn add_author(&mut self, author: String) {
+        self.authors.push(author);
+    }
+
+    pub fn dependencies(&self) -> &Map<String, Value> {
+        &self.dependencies
+    }
+
+    pub fn add_dependency(&mut self, dependency: Dependency) {
+        self.dependencies
+            .insert(dependency.name, Value::String(dependency.version));
+    }
+
+    pub fn set_dependencies(&mut self, dependencies: Vec<Dependency>) {
+        for dependency in dependencies {
+            self.add_dependency(dependency);
+        }
+    }
+
+    // Remove dependency from either of the main or dev dependency lists.
+    pub fn remove_dependency(&mut self, name: &str) {
+        self.remove_main_dependency(name);
+        self.remove_dev_dependency(name);
+    }
+
+    pub fn remove_main_dependency(&mut self, name: &str) {
+        self.dependencies.remove(name);
+    }
+
+    pub fn dev_dependencies(&self) -> &Map<String, Value> {
+        &self.dev_dependencies
+    }
+
+    pub fn add_dev_dependency(&mut self, dependency: Dependency) {
+        self.dev_dependencies
+            .insert(dependency.name, Value::String(dependency.version));
+    }
+
+    pub fn set_dev_dependencies(&mut self, dependencies: Vec<Dependency>) {
+        for dependency in dependencies {
+            self.add_dev_dependency(dependency);
+        }
+    }
+
+    pub fn remove_dev_dependency(&mut self, name: &str) {
+        self.dev_dependencies.remove(name);
+    }
+}

--- a/src/huak/pyproject/tools/mod.rs
+++ b/src/huak/pyproject/tools/mod.rs
@@ -1,0 +1,24 @@
+use serde_derive::{Deserialize, Serialize};
+
+use self::huak::Huak;
+
+pub mod huak;
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct Tool {
+    pub huak: Huak,
+}
+
+impl Tool {
+    pub fn new() -> Tool {
+        Tool::default()
+    }
+
+    pub fn huak(&self) -> &Huak {
+        &self.huak
+    }
+
+    pub fn set_huak(&mut self, huak: Huak) {
+        self.huak = huak
+    }
+}

--- a/src/huak/utils.rs
+++ b/src/huak/utils.rs
@@ -1,7 +1,7 @@
 use crate::errors::CliError;
 use std::{
     env::{self, consts::OS},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 /// Get module filepath from .venv. This function assumes the .venv is in
@@ -29,4 +29,28 @@ pub fn get_venv_bin() -> String {
         "windows" => "Scripts".to_string(),
         _ => "bin".to_string(),
     }
+}
+
+/// Return the filename from a `Path`.
+pub fn get_filename_from_path(path: &Path) -> Result<String, CliError> {
+    // Attempt to convert OsStr to str.
+    let name = match path.file_name() {
+        Some(f) => f.to_str(),
+        _ => {
+            return Err(CliError::new(
+                anyhow::format_err!("failed to read name from path"),
+                2,
+            ))
+        }
+    };
+
+    // If a str was failed to be parsed error.
+    if name.is_none() {
+        return Err(CliError::new(
+            anyhow::format_err!("failed to read name from path"),
+            2,
+        ));
+    }
+
+    Ok(name.unwrap().to_string())
 }


### PR DESCRIPTION
## Summary of changes

    - Expose `Toml` table structs `Tool` and `Huak` as public attributes.
    - Remove ad-hoc stdin utility `create_toml_from_name`.