### PR TITLE
Disable huak-py dependabot temporarily

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "pip"
-    directory: "huak-py"
-    schedule:
-      interval: "weekly"
+  # - package-ecosystem: "pip"
+  #   directory: "huak-py"
+  #   schedule:
+  #     interval: "weekly"


### PR DESCRIPTION
huak-py isn't currently prioritized. when it becomes prioritized we can enable dependabot again.